### PR TITLE
QVM and QUILC engine updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
   - pip3 install --upgrade pip setuptools wheel
   - docker pull rigetti/qvm
   - docker pull rigetti/quilc
-  - docker run --rm -it -p 5000:5000 rigetti/qvm -S &
-  - docker run --rm -it -p 5555:5555 rigetti/quilc -R &
+  - docker run --rm -idt -p 5000:5000 rigetti/qvm -S &
+  - docker run --rm -idt -p 5555:5555 rigetti/quilc -R &
 
 install:
   - pip3 install pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
   - pip3 install --upgrade pip setuptools wheel
   - docker pull rigetti/qvm
   - docker pull rigetti/quilc
-  - docker run --rm -it -p 5000:5000 rigetti/qvm -S
-  - docker run --rm -it -p 5555:5555 rigetti/quilc -R
+  - docker run --rm -it -p 5000:5000 rigetti/qvm -S &
+  - docker run --rm -it -p 5555:5555 rigetti/quilc -R &
 
 install:
   - pip3 install pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install:
   - pip3 install --upgrade pip setuptools wheel
   - docker pull rigetti/qvm
   - docker pull rigetti/quilc
+  - docker run -d -p 5000:5000 rigetti/qvm -S
+  - docker run -d -p 6000:6000 rigetti/quilc -R
 
 install:
   - pip3 install pytest
@@ -23,7 +25,4 @@ install:
 
 
 script:
-  - ls -l - a
-  - rigetti/qvm -S &
-  - rigetti/quilc -S &
   - pytest src/nisqai --cov src/nisqai

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
   - pip3 install --upgrade pip setuptools wheel
   - docker pull rigetti/qvm
   - docker pull rigetti/quilc
-  - docker run -d -p 5000:5000 rigetti/qvm -S
-  - docker run -d -p 6000:6000 rigetti/quilc -R
+  - docker run --rm -it -p 5000:5000 rigetti/qvm -S
+  - docker run --rm -it -p 5555:5555 rigetti/quilc -R
 
 install:
   - pip3 install pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
   - pip3 install --upgrade pip setuptools wheel
   - docker pull rigetti/qvm
   - docker pull rigetti/quilc
-  - docker run --rm -idt -p 5000:5000 rigetti/qvm -S &
-  - docker run --rm -idt -p 5555:5555 rigetti/quilc -R &
+  - docker run --rm -idt -p 5000:5000 rigetti/qvm -S
+  - docker run --rm -idt -p 5555:5555 rigetti/quilc -R
 
 install:
   - pip3 install pytest

--- a/src/nisqai/cost/_quantum_costs_test.py
+++ b/src/nisqai/cost/_quantum_costs_test.py
@@ -12,6 +12,7 @@
 
 
 # TODO: test classes/methods/functions in _quantum_costs.py!
+from nisqai.utils import * #engine,
 from nisqai.cost._quantum_costs import Observable
 import numpy as np
 import unittest
@@ -100,4 +101,15 @@ class TestObservable(unittest.TestCase):
         self.assertAlmostEqual(abs(sum_observables_2), 2, 5)
 
 if __name__ == "__main__":
-    unittest.main()
+    # Initialize engine object
+    en = engine()
+    # Start the servers
+    en.startQVM()
+    en.startQUILC()
+    # Create a forest Object
+    en.forestObject()
+    # Withtout passing exit=False code written below unittest won't get executed
+    unittest.main(exit=False)
+    # Stopping the Servers 
+    en.stopQVM()
+    en.stopQUILC()

--- a/src/nisqai/layer/_base_ansatz_test.py
+++ b/src/nisqai/layer/_base_ansatz_test.py
@@ -61,13 +61,13 @@ def test_depth_empty():
 def test_compile_small():
     """Tests correct compilation for a small circuit."""
     # correct output string
-    correct = ('PRAGMA EXPECTED_REWIRING "#(0 1 2 3 4 5)"'
-               + '\nRX(pi/2) 0'
-               + '\nPRAGMA CURRENT_REWIRING "#(0 1 2 3 4 5)"'
+    correct = ('RX(pi/2) 0'
                + '\nHALT\n')
     ansatz = BaseAnsatz(2)
     ansatz.circuit.inst(gates.RX(pi / 2, 0))
     compiled_circuit = ansatz.compile("6q-qvm")
+    print(compiled_circuit.__str__())
+    print(correct)
     assert compiled_circuit.__str__() == correct
 
 

--- a/src/nisqai/utils/__init__.py
+++ b/src/nisqai/utils/__init__.py
@@ -11,4 +11,4 @@
 #   limitations under the License.
 
 from nisqai.utils._program_utils import order, ascii_drawer_simple
-from nisqai.utils._engine import startQVMandQUILC, stopQVMandQUILC
+from nisqai.utils._engine import engine, checkStatusQVM, checkStatusQUILC

--- a/src/nisqai/utils/_engine.py
+++ b/src/nisqai/utils/_engine.py
@@ -12,6 +12,7 @@
 
 # Imports
 import socket
+import warnings
 import psutil
 from pyquil.api import ForestConnection
 from subprocess import Popen, DEVNULL, STDOUT, check_output
@@ -20,111 +21,193 @@ from subprocess import Popen, DEVNULL, STDOUT, check_output
 class DeactivateQUILCError(Exception):
     pass
 
-
 class DeactivateQVMError(Exception):
     pass
 
+class engine:
 
-def get_free_port():
-    """Returns a free port."""
-    sock = socket.socket()
-    sock.bind(("", 0))
-    port = sock.getsockname()[1]
-    sock.close()
-    return port
+    # Initializing the servers with default: None
+    def __init__(self):
+        self.local_address = 'https://127.0.0.1:'
+        self.qvm_server = None
+        self.qvm_exec = None
+        self.qvm_port = None
+        self.quilc_server = None
+        self.quilc_exec = None
+        self.quilc_port = None
+        self.forest_connection = None
+ 
+    # Activates the QVM server and stores it in qvm_server
+    def startQVM(self, qvm_executable=None, default_port=True):
+        """Activates qvm and quilc server for running pyQuil programs.
 
+        Args:
+            qvm_executable : str
+                Path to the qvm server excecutable.
 
-# TODO: Would be good to have functions startQVM, startQUILC, stopQVM, stopQUILC separately
-def startQVMandQUILC(qvm_executable=None, quilc_executable=None, default_ports=True):
-    """Activates qvm and quilc server for running pyQuil programs.
+            default_port: bool
+                Flat to use default ports specified in pyquilConfig.
 
-    Args:
-        qvm_executable : int
-            Path to the qvm server excecutable.
+        Returns:
 
-        quilc_executable : str
-             Path to the quilc server excecutable.
+        """
+        if self._checkQVM():
+            warnings.warn('Skipping... QVM server is already running!')
+            # Generates list of all running processes
+            proc_list = [x.as_dict(attrs=['pid', 'name'])
+                         for x in list(psutil.process_iter())]
+            # Finds PID of QVM server process
+            pid_data = [x['pid'] for x in proc_list if 'qvm' == x['name']]
+            # Stores it into qvm_server
+            self.qvm_server = psutil.Process(pid_data[0])
 
-        default_ports: bool
-            Flat to use default ports specified in pyquilConfig.
+        else:
+            # Find the standard path of QVM server else
+            # Use the different path which is provided.
+            self.qvm_exec = qvm_executable if qvm_executable is not None else check_output(
+                'type qvm', shell=True, universal_newlines=True).split('\n')[0].split(' ')[-1]
+            
+            # Checks whether standard port is to be used
+            # Or a new one has to be assigned
+            if default_port:
+                self.qvm_server = Popen([self.qvm_exec, "-S"], stdout=DEVNULL, stderr=STDOUT)
+            else:
+                self.qvm_port = self._get_port()
+                self.qvm_server = Popen([self.qvm_exec, "-S", "-p", str(self.qvm_port)],
+                                   stdout=DEVNULL, stderr=STDOUT)
 
-    Returns:
-        qvm_server : Popen object
-        quilc_server : Popen object
-        forest_connection : ForestConnection object
-    """
-    # Quantum virtual machine
-    if qvm_executable is None:
-        qvm_exec = check_output('type qvm', shell=True, universal_newlines=True).split(
-            '\n')[0].split(' ')[-1]
-    else:
-        qvm_exec = qvm_executable
+    # Activates the QUILC server and stores it in quilc_server
+    def startQUILC(self, quilc_executable=None, default_port=True):
+        """Activates qvm and quilc server for running pyQuil programs.
 
-    # Quil compiler
-    if quilc_executable is None:
-        quilc_exec = check_output(
-            'type quilc', shell=True, universal_newlines=True).split('\n')[0].split(' ')[-1]
-    else:
-        quilc_exec = quilc_executable
+        Args:
+            quilc_executable : str
+                Path to the quilc server excecutable.
 
-    # TODO: Comments here. What's this code doing?
-    prev_qvm = check_output(
-        'ps aux | grep "' + qvm_exec + ' -S"', shell=True, universal_newlines=True)
-    prev_quilc = check_output(
-        'ps aux | grep "' + quilc_exec + ' -S"', shell=True, universal_newlines=True)
+            default_ports: bool
+                Flat to use default ports specified in pyquilConfig.
 
-    # TODO: Comments here. What's this code doing?
-    if len(prev_qvm.split('\n')) > 3:
-        proc = psutil.Process(int(prev_qvm.split('  ')[1]))
-        proc.kill()
+        Returns:
 
-    # TODO: Comments here. What's this code doing?
-    if len(prev_quilc.split('\n')) > 3:
-        proc = psutil.Process(int(prev_quilc.split('  ')[1]))
-        proc.kill()
+        """
+        if self._checkQUILC():
+            warnings.warn('Skipping... QUILC server is already running!')
+            # Generates list of all running processes
+            proc_list = [x.as_dict(attrs=['pid', 'name'])
+                         for x in list(psutil.process_iter())]
+            # Finds PID of QUILC server process
+            pid_data = [x['pid'] for x in proc_list if 'quilc' == x['name']]
+            # Stores it into quilc_server
+            self.qvm_server = psutil.Process(pid_data[0])
+ 
+        else:
+            # Find the standard path of QUILC server else
+            # Use the different path which is provided.
+            self.quilc_exec = quilc_executable if quilc_executable is not None else check_output(
+                'type quilc', shell=True, universal_newlines=True).split('\n')[0].split(' ')[-1]
 
-    # TODO: Comments here. What's this code doing?
-    if default_ports:
-        qvm_server = Popen([qvm_exec, "-S"], stdout=DEVNULL, stderr=STDOUT)
-        quilc_server = Popen([quilc_exec, "-S"], stdout=DEVNULL, stderr=STDOUT)
-        fc = ForestConnection(sync_endpoint=None,
-                              compiler_endpoint=None)
-    else:
-        # TODO: any issues with using http instead of https?
-        local_address = 'http://127.0.0.1:'
-        qvm_port = get_free_port()
-        quilc_port = get_free_port()
-        qvm_server = Popen([qvm_exec, "-S", "-p", str(qvm_port)],
-                           stdout=DEVNULL, stderr=STDOUT)
-        quilc_server = Popen([quilc_exec, "-S", "-p", str(quilc_port)], 
-                           stdout=DEVNULL, stderr=STDOUT)
-        fc = ForestConnection(sync_endpoint= local_address + str(qvm_port),
-                              compiler_endpoint= local_address + str(quilc_port))
+            # Checks whether standard port is to be used
+            # Or a new one has to be assigned
+            if default_port:
+                self.quilc_server = Popen([self.quilc_exec, "-R"], stdout=DEVNULL, stderr=STDOUT)
+            else:
+                self.quilc_port = self._get_port()
+                self.quilc_server = Popen([self.quilc_exec, "-R", "-p", str(self.quilc_port)],
+                                     stdout=DEVNULL, stderr=STDOUT)
     
-    return qvm_server, quilc_server, fc
-
-
-def stopQVMandQUILC(qvm_server, quilc_server):
-    """Deactivates qvm and quilc server.
-
-    Args:
-        qvm_server : Popen
-            Popen object for the running qvm server.
-
-        quilc_server : Popen
-            Popen object for the running quilc server.
-    """
-
-    try:
-        qvm_server.terminate()
-
-    # TODO: What specifcially are we excepting here?
-    except:
-        raise Exception("Invalid qvm server.")
     
-    try:
-        quilc_server.terminate()
+    def forestObject(self):
+        """ Makes an ForestConnection object for running pyQuil programs. """
+        if not self._checkQVM():
+            raise Warning('Run the QVM server')
+        elif not self._checkQUILC():
+            raise Warning('Run the QUILC server')
+        else:
+            qvm_url = self.qvm_port if self.qvm_port is None else self.local_address + \
+                str(self.qvm_port)
+            quilc_url = self.quilc_port if self.quilc_port is None else self.local_address + \
+                str(self.quilc_port)
+            # Forest Connections are used when we assign modified ports to the servers
+            self.forest_connection = ForestConnection(sync_endpoint = qvm_url,
+                                      compiler_endpoint = quilc_url)
 
-    # TODO: What specifcially are we excepting here?
-    except:
-        raise Exception("Invalid quilc server.")
+    def _get_port(self):
+        """ Returns a free port."""
+        sock = socket.socket()
+        sock.bind(("", 0))
+        port = sock.getsockname()[1]
+        sock.close()
+        return port
+    
+    def _checkQVM(self):
+        """ Checks running status for QVM server
+        Args:
+        
+        Returns: 
+            status: bool
+                True if any QVM server service is running else return False   
+        """
+        status = True if self.qvm_server is not None else checkStatusQVM()
+        return status
+
+    def _checkQUILC(self):
+        """ Checks running status for QVM server
+        Args:
+
+        Returns: 
+            status: bool
+                True if any QVM server service is running else return False   
+        """
+        status = True if self.quilc_server is not None else checkStatusQUILC()
+        return status
+
+    def stopQVM(self):
+        """ Stops any running service of QVM server """
+
+        if self._checkQVM():
+            self.qvm_server.terminate()
+            self.qvm_server.wait()
+        else:
+            raise Exception('No QVM services running!')
+    
+    def stopQUILC(self):
+        """ Stops any running service of QUILC server """
+
+        if self._checkQUILC():
+            self.quilc_server.terminate()
+            self.quilc_server.wait()
+        else:
+            raise Exception('No QUILC services running!')
+
+def checkStatusQVM():
+    '''
+        Check the status of the QVM server
+        Args: 
+ 
+        Return: 
+            status : (bool) Status of the qvm server executable
+    '''
+    # Generates list of all running processes
+    proc_list = [x.as_dict(attrs=['pid', 'name'])
+                 for x in list(psutil.process_iter())]
+    # Checks if any QVM server process exist in the list
+    proc_data = ['qvm' == x['name'] for x in proc_list]
+    status = True if any(proc_data) else False
+    return status
+
+def checkStatusQUILC():
+    '''
+        Check the status of the QUILC server
+        Args: 
+
+        Return: 
+            status : (bool) 
+                Status of the quilc server executable
+    '''
+    # Generates list of all running processes
+    proc_list = [x.as_dict(attrs=['pid', 'name'])
+                 for x in list(psutil.process_iter())]
+    # Checks if any QUILC server process exist in the list
+    proc_data = ['quilc' == x['name'] for x in proc_list]
+    status = True if any(proc_data) else False
+    return status


### PR DESCRIPTION
As requested in #12 the following has been done:
1. Implemented an `engine` class and hence catching the output is no longer necessary.
2. Implemented separate functions to check the running status of QVM and QUILC servers. `checkStatusQVM` and `checkStatusQUILC`.
3. Separate QVM and QUILC server stop function.
4. Updated your attempt of testing server START and STOP in `cost/_quantum_costs_test.py`. I've tested it, and it seems to work fine.
5. Replaced deprecated HTTPS for RPCQ: [`-S` -> `R`], in QUILC server methods.  